### PR TITLE
Bump jproperties to 2.1.1 & add a 64-byte name length check

### DIFF
--- a/create_alerts.py
+++ b/create_alerts.py
@@ -377,7 +377,12 @@ def alert_already_exists(alert_name):
 
 def build_alert_json(proj_name, alert_name, payload):
     payload = jsons.loads(payload)
-    payload['name'] = proj_name + " - " + alert_name
+    name = proj_name + " - " + alert_name
+
+    # Alert names can only contain up to 64 characters
+    name64 = name[:60] + " ..." if len(name) > 64 else name
+
+    payload["name"] = name64    
     return jsons.dumps(payload)
 
 def generate_url(proj_name, alert_name, alert_type):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2020.12.5
 chardet==4.0.0
 idna==2.10
-jproperties==2.1.0
+jproperties==2.1.1
 jsons==1.4.2
 pytz==2021.1
 requests==2.25.1


### PR DESCRIPTION
Updated jproperties to 2.1.1 to bypass the `collections.abc` MutableMapping error.

Added name length check and modifier to avoid attempting to create an Alert with > 64 byte name.