### PR TITLE
Create alerts for specified projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 ## Summary:
 
 #### The essentials
-- Run this API script to create Alert App Pack rules for ALL projects within an org.
-- :warning: Use the script carefully; it will create alerts for every project in an org. With great power... :spider_web:
-  - A good future feature for this would be to be able to pass it a list of projects to create alerts for. 	
+- Run this API script to create Alert App Pack rules for projects within an org.
+- :warning: By default, it will create alerts for every project in an org.
+- You can also pass a list of projects to create alerts for (see Run Script section)
   
 #### Other things to know
 - The alerts are created without being assigned any teams. SEs or customers will need to assign teams.
@@ -47,7 +47,14 @@ Prior to running create_alerts.py, you can configure the following fields in the
 
 Create Alerts for All Projects
 
-    `$ python3 create_alerts.py`
+```
+// Create alerts for ALL projects
+$ python3 create_alerts.py
+
+// Create alerts only for specified projects by passing one or more project slugs
+// as command-line arguments.
+$ python3 create_alerts.py myproj-javascript otherprojname-python third-proj-react
+```
 
 ## Confirm Alert Creation
 

--- a/create_alerts.py
+++ b/create_alerts.py
@@ -429,7 +429,15 @@ def main(argv):
 
     projects_to_operate_on = argv
 
-    do_setup()    
+    do_setup() 
+
+
+    if not projects_to_operate_on:
+        selection = input(f"Caution: you are about to create alerts for all projects in {configs.get('ORG_NAME').data}.\n  - Continue? y/n:\n")
+        if selection != "y":
+            print("'y' not selected. Exiting program.")
+            sys.exit()
+
     get_alerts()
     get_projects(projects_to_operate_on)
     create_alerts()


### PR DESCRIPTION
- Ability to create alerts for a list of projects passed in via command-line arguments

```
$ python3 create_alerts.py myproj-javascript otherprojname-python third-proj-react
```

![Screen Shot 2022-10-21 at 4 44 53 PM](https://user-images.githubusercontent.com/12092849/197305725-4187e086-b341-469b-910a-d7f270bd981c.png)

![Screen Shot 2022-10-21 at 4 45 21 PM](https://user-images.githubusercontent.com/12092849/197305743-20a838bf-4914-4e9a-8d53-baf635d89871.png)

- For safety, if no set list of projects is passed in, require user to confirm they want to create alerts for all projects:

![Screen Shot 2022-10-21 at 4 45 57 PM](https://user-images.githubusercontent.com/12092849/197305774-6c4985b8-c4e7-4ae6-b5aa-8053196433ee.png)



